### PR TITLE
feat: add 'user_prefix' option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*Session*.vim

--- a/lua/sj/init.lua
+++ b/lua/sj/init.lua
@@ -33,7 +33,7 @@ function M.run(opts)
 		end
 	end
 
-	local user_input, labels_map = core.get_user_input()
+	local user_input, labels_map = core.get_user_input(opts.user_prefix)
 	core.extract_range_and_jump_to(user_input, labels_map)
 end
 


### PR DESCRIPTION
Hi @woosaaahh, long time no see.

This is a draft of a feature that would add a "user_prefix" option when users call `sj.run()`.
If the user wants to search jump to some patterns over and over again, instead of manually typing the pattern, they can use this "user_prefix" option to automatically type that pattern whenever they press the keymap.

I'd love to hear your feedback on this. Thanks for the amazing plugin :+1: 